### PR TITLE
fix: Liquid Exception: missing keyword: :ssr

### DIFF
--- a/lib/jekyll/vite/tags.rb
+++ b/lib/jekyll/vite/tags.rb
@@ -73,7 +73,7 @@ protected
   # Internal: Adding the last build metadata file as a dependency ensures
   # all pages using Vite assets are regenerated if a Vite build is triggered.
   def last_build_metadata_path
-    ViteRuby.instance.builder.send(:last_build_path)
+    ViteRuby.instance.builder.send(:last_build_path, ssr: false)
   end
 end
 


### PR DESCRIPTION
### Description 📖

At least in ruby 3.1.0, the demo is broken with this error :
```
Liquid Exception: missing keyword: :ssr in /home/matmorel/jekyll-vite/docs/_layouts/default.html
bundler: failed to load command: jekyll (/home/matmorel/.asdf/installs/ruby/3.1.0/bin/jekyll)
```

### Background 📜

That's because [`last_build_path`](https://github.com/ElMassimo/vite_ruby/blob/main/vite_ruby/lib/vite_ruby/builder.rb#L45) must receive the `:ssr` option, based on [`last_build_metadata`](https://github.com/ElMassimo/vite_ruby/blob/main/vite_ruby/lib/vite_ruby/builder.rb#L28) I assumed that the option must be `false`.

### The Fix 🔨
I added `ssr: false` to `last_build_path` call from the `last_build_metadata_path` method in the `lib/jekyll/vite/tags.rb` file.