### PR TITLE
fix: add `rackup` as a dependency

### DIFF
--- a/jekyll-vite.gemspec
+++ b/jekyll-vite.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'jekyll', '>= 3', '< 5'
   s.add_dependency 'vite_ruby', '~> 3.2'
+  s.add_dependency 'rackup', '~> 0.2'
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'

--- a/lib/jekyll/vite/proxy.rb
+++ b/lib/jekyll/vite/proxy.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rack'
+require 'rackup'
 require 'jekyll/commands/serve/servlet'
 
 # Internal: Extend the default servlet to add a Rack-based proxy in order to
@@ -45,7 +46,7 @@ private
       proxy = ViteRuby::DevServerProxy.new(app)
 
       # Return a servlet compliant with WEBrick.
-      Rack::Handler::WEBrick.new(@server, proxy)
+      Rackup::Handler::WEBrick.new(@server, proxy)
     end
   end
 end


### PR DESCRIPTION
### Description 📖

This pull request fix a crash that occur when using `rack` 3.0.0
```
ERROR LoadError: cannot load such file -- rack/handler
```

### Background 📜

This was happening because `rack` 3.0.0 has been release recently. `rack-proxy` doesn't fix the `rack` version, resulting in installing and using version 3.0.0 when running `bundle install` for the first time.

This version introduce some breaking changes : in our case, rack handlers have been moved into a separate gem named `rackup`

### The Fix 🔨

Using the `rackup` gem instead of `rack` to get handlers.

